### PR TITLE
Make pathFD error message more explicit

### DIFF
--- a/spec/unit/tester/test_asserter.rb
+++ b/spec/unit/tester/test_asserter.rb
@@ -49,35 +49,38 @@ module Webspicy
       describe '#pathFD' do
         let(:target) { {
           bla: "bla",
-          content: [{
+          array: [{
             bli: "bli",
-            content: {
+            fstLevel: {
               blo: "blo",
-              content: {
+              sndLevel: {
                 blu: "blu",
                 number: 3
               }
             }
           }, {
             ble: "ble",
-            content: {
+            fstLevel: {
               bly: "bly",
-              content: {
+              sndLevel: {
                 blur: "blur",
-                number: 4
+                number: 4,
+                x: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                y: "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+                z: "error"
               }
             }
           }]
         } }
 
         it 'returns nil when the assertion is true' do
-          expect(asserter.pathFD('content/1/content/content', number: 4)).to eq nil
+          expect(asserter.pathFD('array/1/fstLevel/sndLevel', number: 4)).to eq nil
         end
 
         it 'raises an exception with a descriptive message when the assertion is false' do
-          expect { asserter.pathFD('content/1/content/content', number: 3) }
+          expect { asserter.pathFD('array/1/fstLevel/sndLevel', z: 'z') }
             .to raise_exception RuntimeError,
-                                '{:number=>3} vs. {"blur":"blur","number":4}...'
+                                '{:z=>z} vs. {"z":"error",...'
         end
       end
 

--- a/spec/unit/tester/test_asserter.rb
+++ b/spec/unit/tester/test_asserter.rb
@@ -45,7 +45,42 @@ module Webspicy
           end
         end
       end
+
+      describe '#pathFD' do
+        let(:target) { {
+          bla: "bla",
+          content: [{
+            bli: "bli",
+            content: {
+              blo: "blo",
+              content: {
+                blu: "blu",
+                number: 3
+              }
+            }
+          }, {
+            ble: "ble",
+            content: {
+              bly: "bly",
+              content: {
+                blur: "blur",
+                number: 4
+              }
+            }
+          }]
+        } }
+
+        it 'returns nil when the assertion is true' do
+          expect(asserter.pathFD('content/1/content/content', number: 4)).to eq nil
+        end
+
+        it 'raises an exception with a descriptive message when the assertion is false' do
+          expect { asserter.pathFD('content/1/content/content', number: 3) }
+            .to raise_exception RuntimeError,
+                                '{:number=>3} vs. {"blur":"blur","number":4}...'
+        end
+      end
+
     end
   end
 end
-


### PR DESCRIPTION
I would like this error message to locate the mismatch exactly.
I suggest a message like:

```
Expected { ... bla: bli,  foo: drak } to match { ... bla: blo ... }
               ^^^^^^^^
```
