### PR TITLE
Assertion failure message improvements

### DIFF
--- a/lib/webspicy/tester/asserter.rb
+++ b/lib/webspicy/tester/asserter.rb
@@ -78,7 +78,12 @@ module Webspicy
           expected = id
           id, path = path, ''
         end
-        unless @assertions.idFD(@target, path, id, expected)
+        element = @assertions.element_with_id(@target, path, id)
+        unless element
+          _! "Expected an element with id #{id} to contain the key(s) and value(s) #{expected}, but there is no element with that id"
+        end
+
+        unless @assertions.idFD(element, expected)
           _! "Expected #{_s(@target, path)} to contain the key(s) and value(s) #{expected}"
         end
       end

--- a/lib/webspicy/tester/asserter.rb
+++ b/lib/webspicy/tester/asserter.rb
@@ -79,13 +79,13 @@ module Webspicy
           id, path = path, ''
         end
         unless @assertions.idFD(@target, path, id, expected)
-          _! "Expected #{_s(@target, path)} to meet FD #{expected.inspect}"
+          _! "Expected #{_s(@target, path)} to contain the key(s) and value(s) #{expected}"
         end
       end
 
       def pathFD(path, expected)
         unless @assertions.pathFD(@target, path, expected)
-          _! "#{expected.inspect} vs. #{_s(@target, path)}"
+          _! "Expected #{_s(@target, path)} to contain the key(s) and value(s) #{expected}"
         end
       end
 

--- a/lib/webspicy/tester/assertions.rb
+++ b/lib/webspicy/tester/assertions.rb
@@ -63,16 +63,15 @@ module Webspicy
         (ids.to_set & expected.to_set).empty?
       end
 
-      def idFD(target, path, id, expected = NO_ARG)
-        if expected == NO_ARG
-          expected = id
-          id, path = path, ''
-        end
+      def element_with_id(target, path, id)
         target = extract_path(target, path)
-        found = an_array(target).find{|t| t[:id] == id }
-        expected.keys.all?{|k|
-          value_equal(expected[k], found[k])
-        }
+        an_array(target).find { |t| t[:id] == id }
+      end
+
+      def idFD(element, expected) 
+        expected.keys.all? do |k|
+          value_equal(expected[k], element[k])
+        end
       end
 
       def pathFD(target, path, expected)

--- a/spec/unit/tester/test_asserter.rb
+++ b/spec/unit/tester/test_asserter.rb
@@ -172,10 +172,12 @@ module Webspicy
       it 'raises an exception when the assertion is false' do
         expect { Asserter.new(target).idFD('', 2, { c: 'c2' }) }
           .to raise_exception RuntimeError,
-                              'Expected [{"id":1,"a":"a1","b":"b1"... to meet FD {:c=>"c2"}'
+                              'Expected [{"id":1,"a":"a1","b":"b1"... ' \
+                              'to contain the key(s) and value(s) {:c=>"c2"}'
         expect { Asserter.new(target).idFD('', 2, { b: 'b1' }) }
           .to raise_exception RuntimeError,
-                              'Expected [{"id":1,"a":"a1","b":"b1"... to meet FD {:b=>"b1"}'
+                              'Expected [{"id":1,"a":"a1","b":"b1"... ' \
+                              'to contain the key(s) and value(s) {:b=>"b1"}'
       end
 
       it 'raises a NoMethodError when no element with the specified id is present' do
@@ -203,10 +205,12 @@ module Webspicy
       it 'raises an exception when the assertion is false' do
         expect { Asserter.new(target).pathFD('0', { c: 'c2' }) }
           .to raise_exception RuntimeError,
-                              '{:c=>"c2"} vs. {"a":"a1","b":"b1"}'
+                              'Expected {"a":"a1","b":"b1"} ' \
+                              'to contain the key(s) and value(s) {:c=>"c2"}'
         expect { Asserter.new(target).pathFD('0', { b: 'b2' }) }
           .to raise_exception RuntimeError,
-                              '{:b=>"b2"} vs. {"a":"a1","b":"b1"}'
+                              'Expected {"a":"a1","b":"b1"} ' \
+                              'to contain the key(s) and value(s) {:b=>"b2"}'
       end
     end
 

--- a/spec/unit/tester/test_asserter.rb
+++ b/spec/unit/tester/test_asserter.rb
@@ -180,10 +180,12 @@ module Webspicy
                               'to contain the key(s) and value(s) {:b=>"b1"}'
       end
 
-      it 'raises a NoMethodError when no element with the specified id is present' do
+      it 'raises an exception with a descriptive message when no element with the specified id is present in target' do
         expect { Asserter.new(target).idFD('', 3, { a: 'a3' }) }
-          .to raise_exception NoMethodError,
-                              'undefined method `[]\' for nil:NilClass'
+          .to raise_exception RuntimeError,
+                              'Expected an element with id 3 to contain ' \
+                              'the key(s) and value(s) {:a=>"a3"}, '\
+                              'but there is no element with that id'
       end
     end
 

--- a/spec/unit/tester/test_assertions.rb
+++ b/spec/unit/tester/test_assertions.rb
@@ -96,14 +96,16 @@ module Webspicy
           { id: 1, bar: "bar" },
           { id: 2, bar: "baz" }
         ] }
-        expect(idFD(target, 'foo', 1, bar: "bar")).to be(true)
-        expect(idFD(target, 'foo', 1, bar: "baz")).to be(false)
-        expect(idFD(target, 'foo', 1, baz: "boz")).to be(false)
+        element = element_with_id(target, 'foo', 1)
+        expect(idFD(element, bar: "bar")).to be(true)
+        expect(idFD(element, bar: "baz")).to be(false)
+        expect(idFD(element, baz: "boz")).to be(false)
 
         target = { foo: { id: 1, bar: "bar" } }
-        expect(idFD(target, 'foo', 1, bar: "bar")).to be(true)
-        expect(idFD(target, 'foo', 1, bar: "baz")).to be(false)
-        expect(idFD(target, 'foo', 1, baz: "boz")).to be(false)
+        element = element_with_id(target, 'foo', 1)
+        expect(idFD(element, bar: "bar")).to be(true)
+        expect(idFD(element, bar: "baz")).to be(false)
+        expect(idFD(element, baz: "boz")).to be(false)
       end
 
       it 'has a pathFD assertion' do


### PR DESCRIPTION
## idFD/pathFD
`Expected [{"id":1,"a":"a1","b":"b1"... to meet FD {:c=>"c2"}` => `Expected [{"id":1,"a":"a1","b":"b1"... to contain the key(s) and value(s) {:c=>"c2"}`

## idFD when the id is not in the collection at all

before: `crash with `undefined method `[]' for nil:NilClass'`

after: `Expected an element with id 3 to contain the key(s) and value(s) {:a=>"a3"}, but there is no element with that id'`