### PR TITLE
Added a link to the list of available options and env parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Then execute webspicy help to see the options.
 ```
 webspicy --help
 ```
+Alternatively, you can see the available options [here](./bin/webspicy).
 
 ## Using the docker image(s)
 


### PR DESCRIPTION
It's the easiest way to find them, when you don't have webspicy installed you don't remember how to run it with `-h`.